### PR TITLE
Preserve current slide after single export

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -157,13 +157,12 @@ function App() {
 
     const originalPostIndex = currentPostIndex;
     
+    const startIdx = singleSlide ? originalPostIndex : 0;
+    const endIdx = singleSlide ? originalPostIndex + 1 : posts.length;
+
     try {
       const timestamp = getTimestamp();
-      
-      // Export single or all posts
-      const startIdx = singleSlide ? originalPostIndex : 0;
-      const endIdx = singleSlide ? originalPostIndex + 1 : posts.length;
-      
+
       for (let i = startIdx; i < endIdx; i++) {
         // Wait a bit between exports to avoid issues
         if (i > startIdx) {
@@ -199,15 +198,15 @@ function App() {
         saveAs(dataUrl, filename);
       }
       
+    } catch (error) {
+      console.error('Error exporting image:', error);
+    } finally {
       if (singleSlide) {
         setCurrentPostIndex(originalPostIndex);
-      } else {
+      } else if (posts.length > 0) {
         // Reset to first post for full exports
         setCurrentPostIndex(0);
       }
-      
-    } catch (error) {
-      console.error('Error exporting image:', error);
     }
   };
 


### PR DESCRIPTION
## Summary
- capture the preview's starting slide index before exporting
- reuse the captured index after single-slide exports so navigation remains unchanged
- keep the reset-to-first-slide behavior for full exports only

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_690104c3611c832faa1f1df718cbfe39