### PR TITLE
Preserve preview position after single-slide export

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -176,6 +176,10 @@ function App() {
 
     try {
       const timestamp = getTimestamp();
+      const originalPostIndex = Math.min(
+        Math.max(currentPostIndex, 0),
+        posts.length - 1
+      );
 
       // Export single or all posts
       const clampedCurrentIndex = Math.min(
@@ -228,9 +232,13 @@ function App() {
         saveAs(dataUrl, filename);
       }
 
-      // Reset to first post
-      setCurrentPostIndex(0);
-      
+      if (singleSlide) {
+        setCurrentPostIndex(originalPostIndex);
+      } else {
+        // Reset to first post after exporting all slides
+        setCurrentPostIndex(0);
+      }
+
     } catch (error) {
       console.error('Error exporting image:', error);
     }


### PR DESCRIPTION
## Summary
- clamp and capture the current preview index at the start of export
- restore the original slide after single-slide exports while keeping the full export reset

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_69010c363470832fa60214023e1b944f