### PR TITLE
Improve action button responsiveness

### DIFF
--- a/src/components/PostEditor.jsx
+++ b/src/components/PostEditor.jsx
@@ -62,6 +62,21 @@ const ActionButtons = styled.div`
   justify-content: flex-end;
   gap: ${({ theme }) => theme.spacing.md};
   margin-top: ${({ theme }) => theme.spacing.md};
+  flex-wrap: wrap;
+
+  @media (max-width: 1024px) {
+    justify-content: center;
+  }
+
+  @media (max-width: 768px) {
+    flex-direction: column;
+    align-items: stretch;
+
+    ${Button} {
+      width: 100%;
+      justify-content: center;
+    }
+  }
 `;
 
 const HiddenFileInput = styled.input`


### PR DESCRIPTION
## Summary
- allow editor action buttons to wrap and center on medium viewports
- stack buttons vertically with full-width layout on narrow viewports for clarity

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_69010c5db9dc832f90349115d1d9f22c