### PR TITLE
Improve multi-image layouts in preview

### DIFF
--- a/src/components/PostPreview.jsx
+++ b/src/components/PostPreview.jsx
@@ -162,7 +162,10 @@ const PreviewContent = styled.div`
 
 const ImageSection = styled.div`
   display: flex;
-  flex-direction: column;
+  flex-direction: ${({ imagePosition }) =>
+    ['left', 'right'].includes(imagePosition) ? 'column' : 'row'};
+  flex-wrap: ${({ imagePosition }) =>
+    ['top', 'bottom'].includes(imagePosition) ? 'nowrap' : 'wrap'};
   gap: ${({ theme }) => theme.spacing.sm};
   width: ${({ imagePosition }) =>
     ['left', 'right'].includes(imagePosition) ? '40%' : '100%'};
@@ -171,6 +174,9 @@ const ImageSection = styled.div`
   flex-shrink: 0;
   overflow-y: ${({ imagePosition }) =>
     ['left', 'right'].includes(imagePosition) ? 'auto' : 'visible'};
+  overflow-x: ${({ imagePosition }) =>
+    ['top', 'bottom'].includes(imagePosition) ? 'auto' : 'hidden'};
+  align-items: stretch;
   scrollbar-width: none;
   -ms-overflow-style: none;
 
@@ -184,6 +190,7 @@ const StyledImage = styled.img`
   height: auto;
   border-radius: 4px;
   display: block;
+  object-fit: cover;
 `;
 
 const TextContent = styled.div`
@@ -286,17 +293,25 @@ const PostPreview = React.forwardRef(({ content, metadata = {} }, ref) => {
           {/* Render images before content for 'top' and 'left' positions */}
           {['top', 'left'].includes(imagePosition) && images.length > 0 && (
             <ImageSection imagePosition={imagePosition} className="hide-scrollbar">
-              {images.map((img, idx) => (
-                <StyledImage
-                  key={idx}
-                  src={img.src}
-                  alt={img.alt || 'image'}
-                  onError={(e) => {
-                    console.error('Image failed to load:', img.src.substring(0, 50));
-                    e.target.style.display = 'none';
-                  }}
-                />
-              ))}
+              {images.map((img, idx) => {
+                const imageWidth = `${100 / images.length}%`;
+                const sharedImageStyles = ['top', 'bottom'].includes(imagePosition)
+                  ? { flex: `0 0 ${imageWidth}`, maxWidth: imageWidth }
+                  : {};
+
+                return (
+                  <StyledImage
+                    key={idx}
+                    src={img.src}
+                    alt={img.alt || 'image'}
+                    style={sharedImageStyles}
+                    onError={(e) => {
+                      console.error('Image failed to load:', img.src.substring(0, 50));
+                      e.target.style.display = 'none';
+                    }}
+                  />
+                );
+              })}
             </ImageSection>
           )}
 
@@ -347,17 +362,25 @@ const PostPreview = React.forwardRef(({ content, metadata = {} }, ref) => {
           {/* Render images after content for 'bottom' and 'right' positions */}
           {['bottom', 'right'].includes(imagePosition) && images.length > 0 && (
             <ImageSection imagePosition={imagePosition} className="hide-scrollbar">
-              {images.map((img, idx) => (
-                <StyledImage
-                  key={idx}
-                  src={img.src}
-                  alt={img.alt || 'image'}
-                  onError={(e) => {
-                    console.error('Image failed to load:', img.src.substring(0, 50));
-                    e.target.style.display = 'none';
-                  }}
-                />
-              ))}
+              {images.map((img, idx) => {
+                const imageWidth = `${100 / images.length}%`;
+                const sharedImageStyles = ['top', 'bottom'].includes(imagePosition)
+                  ? { flex: `0 0 ${imageWidth}`, maxWidth: imageWidth }
+                  : {};
+
+                return (
+                  <StyledImage
+                    key={idx}
+                    src={img.src}
+                    alt={img.alt || 'image'}
+                    style={sharedImageStyles}
+                    onError={(e) => {
+                      console.error('Image failed to load:', img.src.substring(0, 50));
+                      e.target.style.display = 'none';
+                    }}
+                  />
+                );
+              })}
             </ImageSection>
           )}
         </PreviewContent>

--- a/src/components/PostPreview.jsx
+++ b/src/components/PostPreview.jsx
@@ -174,8 +174,7 @@ const ImageSection = styled.div`
   flex-shrink: 0;
   overflow-y: ${({ imagePosition }) =>
     ['left', 'right'].includes(imagePosition) ? 'auto' : 'visible'};
-  overflow-x: ${({ imagePosition }) =>
-    ['top', 'bottom'].includes(imagePosition) ? 'auto' : 'hidden'};
+  overflow-x: auto;
   align-items: stretch;
   scrollbar-width: none;
   -ms-overflow-style: none;

--- a/src/components/PostPreview.jsx
+++ b/src/components/PostPreview.jsx
@@ -164,16 +164,15 @@ const ImageSection = styled.div`
   display: flex;
   flex-direction: ${({ imagePosition }) =>
     ['left', 'right'].includes(imagePosition) ? 'column' : 'row'};
-  flex-wrap: ${({ imagePosition }) =>
-    ['top', 'bottom'].includes(imagePosition) ? 'nowrap' : 'wrap'};
+  flex-wrap: nowrap;
   gap: ${({ theme }) => theme.spacing.sm};
   width: ${({ imagePosition }) =>
     ['left', 'right'].includes(imagePosition) ? '40%' : '100%'};
   max-width: ${({ imagePosition }) =>
     ['left', 'right'].includes(imagePosition) ? '45%' : '100%'};
   flex-shrink: 0;
-  overflow-y: ${({ imagePosition }) =>
-    ['left', 'right'].includes(imagePosition) ? 'auto' : 'visible'};
+  max-height: 100%;
+  overflow-y: auto;
   overflow-x: auto;
   align-items: stretch;
   scrollbar-width: none;


### PR DESCRIPTION
## Summary
- adjust the image section to flex between column and row layouts based on the chosen image position
- distribute top and bottom image slots evenly and allow horizontal scrolling when needed
- ensure preview images cover their allocated space for consistent presentation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_690276719d10832f9a322dadbe609a96